### PR TITLE
!HOTFIX/#5 Add a comma between different labels

### DIFF
--- a/src/nlp/schemas.py
+++ b/src/nlp/schemas.py
@@ -5,7 +5,7 @@ Lang = Literal["ko", "en", "unknown"]
 
 # 넓게 허용
 NERLabel = Literal[
-    "Activity", "Location", "Person", "Project", "Topic", "Organization", "Food", "Movie", "TVShow", "Animal"
+    "Activity", "Location", "Person", "Project", "Topic", "Organization", "Food", "Movie", "TVShow", "Animal",
     "Date", "None" # "Particle", "Preposition", "Verb", "Adjective", "Adverb", "Conjunction"
 ]
 


### PR DESCRIPTION
# Overview

### schemas.py
```python
NERLabel = Literal[
    "Activity", "Location", "Person", "Project", "Topic", "Organization", "Food", "Movie", "TVShow", "Animal"
    "Date", "None" # "Particle", "Preposition", "Verb", "Adjective", "Adverb", "Conjunction"
]
```
위 파일 내의 NERLabel 값 작성 과정에서 Animal 뒤에 `,`를 누락하여 AnimalDate라는 하나의 Label이 존재하고 있었음

파이썬 특성상 문자열 리터럴을 바로 이어 붙이면 자동으로 결합되기 때문에 `"Animal" "Date", ...`처럼 중간에 `,`가 빠진 부분이 있었던 탓에 "Animal"과 "Date"가 붙어서 "AnimalDate"라는 하나의 문자열이 됐었고 이 때문에 의도한 동작이 이뤄지지 않고 있었음

이를 수정하기 위한 작업

[수정 후 Test 결과](https://github.com/Calabi-Yau-Ontology/calabi-ml-server/issues/5#issuecomment-3695776330)

Closes #5 